### PR TITLE
Documentation of Button IDs for various LG Remotes

### DIFF
--- a/Button IDs.md
+++ b/Button IDs.md
@@ -1,0 +1,62 @@
+# Remote Button IDs
+This file details the IDs of each of the buttons on some LG Remotes. These IDs are based on individual testing and may not always be accurate. Use them at your own discretion. 
+
+## LG Magic Remote (Model [MR21GC](https://www.lg.com/au/tv-accessories/lg-akb76036504 "MR21GC"))
+### Power Button
+I have neither been able to remap nor even identify what the default mapping for the Power Button is. The input from that button is processed before the inputhook can grab it.
+### Number Pad
+|Button|ID|
+|-|-|
+|1|2|
+|2|3|
+|3|4|
+|4|5|
+|5|6|
+|6|7|
+|7|8|
+|8|9|
+|9|10|
+|0|11|
+|List|787|
+|...|994|
+### Volume & Channel Controls
+|Button|ID|
+|-|-|
+|Volume +|115|
+|Volume -|114|
+|Channel +|402|
+|Channel -|403|
+|Mute|113|
+### Other Menus / "Smart" Functions
+|Button|ID|
+|-|-|
+|Home|773|
+|Voice Assistant|428|
+|Inputs|241|
+|Settings|139|
+### Navigation
+|Button|ID|
+|-|-|
+|D-Pad Up|103|
+|D-Pad Down|108|
+|D-Pad Left|105|
+|D-Pad Right|106|
+|Scroll Wheel Click|272|
+|Back|412|
+*The scrolling of the wheel does not get logged by the input hook and so, probably cannot be remapped.*
+### Colours
+|Button|ID|
+|-|-|
+|Red|398|
+|Green|399|
+|Yellow|400|
+|Blue|401|
+### Shortcuts
+|Button|ID|
+|-|-|
+|Netflix|1037|
+|Prime Video|1038|
+|Disney+|1042|
+|Rakuten TV|1044|
+|Google Assistant|1117|
+|Alexa|1086|

--- a/Button IDs.md
+++ b/Button IDs.md
@@ -43,6 +43,7 @@ I have neither been able to remap nor even identify what the default mapping for
 |D-Pad Right|106|
 |Scroll Wheel Click|272|
 |Back|412|
+
 *The scrolling of the wheel does not get logged by the input hook and so, probably cannot be remapped.*
 ### Colours
 |Button|ID|


### PR DESCRIPTION
I created a file to document the Button IDs for various LG remotes. Finding the IDs for my Magic Remote was quite an annoying process, and since I had documented everything already, I figured I'd save other folks some annoyance :)